### PR TITLE
Add checklist item to report value to the client

### DIFF
--- a/checklists/sprint_meeting.md
+++ b/checklists/sprint_meeting.md
@@ -1,10 +1,11 @@
 - [ ] Check with everyone if Trello represents what has been and shall be done.
+- [ ] Remember to report to the client the value that is being delivered from that sprint instead of technical stuff (do that only if necessary).
 - [ ] Report things that are going well. Celebrate success.
 - [ ] Report problems being faced.
 - [ ] Report risks and known issues. Discuss how to address them.
 - [ ] Talk about next steps.
 - [ ] Ask about unclear topics. 
-- [ ] Ask about client expectations on what is being and will be done . Check if progress is aligned with budget and schedule expectations.
+- [ ] Ask about client expectations on what is being and will be done. Check if progress is aligned with budget and schedule expectations.
 - [ ] Always ask about priorities and discuss if there is something more important than what is being worked on. 
 - [ ] Take notes during meeting, use a service you can save online like Google Docs.
 - [ ] After meeting, add notes to a Trello card under  Documents column and update other cards if necessary.


### PR DESCRIPTION
We're used to report things we did to the client in a technical way, talking more about the feature and less about the value added to the their product. This checklist item aims to remind that it's important to report in a way that they understand.