### PR TITLE
Remove design guidelines

### DIFF
--- a/guidelines.md
+++ b/guidelines.md
@@ -1,5 +1,4 @@
 * [Frontend](guidelines/guideline_frontend.md)
-* [Design](guidelines/guideline_design.md)
 * [Landing Pages](guidelines/guideline_landing_pages.md)
 * [Management with Asana](guidelines/guideline_asana.md)
 * [Presentation](guidelines/guideline_presentations.md)


### PR DESCRIPTION
Design guidelines are outdated and I don't think they belong here. I'm writing a whole new Design section for the playbook.

- Aline